### PR TITLE
Fix Google login silently failing after account selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,14 +112,16 @@ window.signInWithGoogle=async()=>{
   }
   try{
     if(shouldPreferGoogleRedirect()){
+      sessionStorage.setItem('pendingGoogleRedirect','1');
       await signInWithRedirect(auth,prov);
       return;
     }
     await signInWithPopup(auth,prov);
   }catch(e){
+    sessionStorage.removeItem('pendingGoogleRedirect');
     const fallbackCodes=['auth/popup-blocked','auth/cancelled-popup-request','auth/operation-not-supported-in-this-environment','auth/internal-error'];
     if(fallbackCodes.includes(e.code)){
-      try{await signInWithRedirect(auth,prov);return;}catch(redirectErr){handleGoogleLoginError(redirectErr);}
+      try{sessionStorage.setItem('pendingGoogleRedirect','1');await signInWithRedirect(auth,prov);return;}catch(redirectErr){handleGoogleLoginError(redirectErr);}
     }else{
       handleGoogleLoginError(e);
     }
@@ -127,8 +129,19 @@ window.signInWithGoogle=async()=>{
   }
 };
 getRedirectResult(auth)
-  .then(()=>resetLoginButton())
-  .catch(e=>{handleGoogleLoginError(e);resetLoginButton();});
+  .then(result=>{
+    const wasPending=sessionStorage.getItem('pendingGoogleRedirect');
+    sessionStorage.removeItem('pendingGoogleRedirect');
+    if(wasPending&&!result?.user){
+      showToast('Sign-in incomplete','Google sign-in did not complete. Please try again.');
+    }
+    resetLoginButton();
+  })
+  .catch(e=>{
+    sessionStorage.removeItem('pendingGoogleRedirect');
+    handleGoogleLoginError(e);
+    resetLoginButton();
+  });
 let _unsubscribeProfile=null;
 window.signOut=async()=>{
   if(_unsubscribeProfile){_unsubscribeProfile();_unsubscribeProfile=null;}

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -9,9 +9,12 @@ export function shouldPreferGoogleRedirect(
     matchMediaLike?.('(display-mode: standalone)')?.matches || navigatorLike?.standalone === true
   );
   const inAppBrowser = /Instagram|FBAN|FBAV|Line|wv/i.test(userAgent);
+  // Use popup only on localhost dev; all deployed environments use redirect because
+  // signInWithPopup silently fails on modern browsers with cross-origin cookie restrictions.
+  const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '';
 
   return (
-    host.endsWith('github.io') ||
+    !isLocalhost ||
     standalone ||
     inAppBrowser ||
     /iPad|iPhone|iPod/i.test(userAgent)

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -23,6 +23,26 @@ describe('login helpers', () => {
     ).toBe(true);
   });
 
+  it('prefers redirect on any deployed (non-localhost) domain', () => {
+    expect(
+      shouldPreferGoogleRedirect(
+        { hostname: 'mycustomdomain.com' },
+        { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' },
+        () => ({ matches: false })
+      )
+    ).toBe(true);
+  });
+
+  it('uses popup on localhost dev environment', () => {
+    expect(
+      shouldPreferGoogleRedirect(
+        { hostname: 'localhost' },
+        { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' },
+        () => ({ matches: false })
+      )
+    ).toBe(false);
+  });
+
   it('explains unauthorized domain failures clearly', () => {
     expect(getGoogleLoginErrorMessage({ code: 'auth/unauthorized-domain' }, 'toskawales.github.io')).toContain(
       'Authorized domains'


### PR DESCRIPTION
signInWithPopup fails silently in modern browsers because cross-origin
cookie restrictions block the postMessage from the OAuth popup back to
the parent window. The user sees the Google account picker, selects an
account, the popup closes, but auth state never updates.

Fix: expand shouldPreferGoogleRedirect to use the more reliable
signInWithRedirect flow for all non-localhost deployments, not just
github.io. Localhost dev still uses popup for faster iteration.

Also add a sessionStorage flag so a lost redirect state surfaces a
"Sign-in incomplete" toast instead of silently leaving the user on the
login screen.

https://claude.ai/code/session_01LvxxCNMAP4iaAFco7CAhX5