### PR TITLE
Fix login: always use signInWithPopup, drop broken signInWithRedirect path

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 import{signInWithPopup,signInWithRedirect,getRedirectResult,signOut as fbSO,onAuthStateChanged}from'https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js';
 import{doc,setDoc,getDoc,deleteDoc,collection,addDoc,getDocs,query,orderBy,limit,where,serverTimestamp,onSnapshot}from'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
-import{shouldPreferGoogleRedirect,getGoogleLoginErrorMessage}from'./src/modules/auth.js';
+import{shouldPreferGoogleRedirect,isInAppBrowser,getGoogleLoginErrorMessage}from'./src/modules/auth.js';
 import{createFirebaseServices}from'./src/modules/firestore.js';
 import{getGoalAdherenceInsights,getWeeklyProgressSummary}from'./src/modules/insights.js';
 import{buildFirstRunEmptyState,getRecommendedFocusMuscles,getRecommendedTrainingSetup}from'./src/modules/onboarding.js';
@@ -110,18 +110,21 @@ window.signInWithGoogle=async()=>{
     resetLoginButton();
     return;
   }
+  if(isInAppBrowser()){
+    showToast('Open in your browser','Google sign-in doesn\'t work inside apps like Instagram or Facebook. Tap the menu and choose "Open in browser".');
+    resetLoginButton();
+    return;
+  }
   try{
-    if(shouldPreferGoogleRedirect()){
-      sessionStorage.setItem('pendingGoogleRedirect','1');
-      await signInWithRedirect(auth,prov);
-      return;
-    }
     await signInWithPopup(auth,prov);
   }catch(e){
-    sessionStorage.removeItem('pendingGoogleRedirect');
-    const fallbackCodes=['auth/popup-blocked','auth/cancelled-popup-request','auth/operation-not-supported-in-this-environment','auth/internal-error'];
+    const fallbackCodes=['auth/popup-blocked','auth/cancelled-popup-request','auth/operation-not-supported-in-this-environment'];
     if(fallbackCodes.includes(e.code)){
-      try{sessionStorage.setItem('pendingGoogleRedirect','1');await signInWithRedirect(auth,prov);return;}catch(redirectErr){handleGoogleLoginError(redirectErr);}
+      try{
+        sessionStorage.setItem('pendingGoogleRedirect','1');
+        await signInWithRedirect(auth,prov);
+        return;
+      }catch(redirectErr){handleGoogleLoginError(redirectErr);}
     }else{
       handleGoogleLoginError(e);
     }

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,24 +1,17 @@
+export function isInAppBrowser(navigatorLike = globalThis.navigator) {
+  return /Instagram|FBAN|FBAV|Line|wv/i.test(navigatorLike?.userAgent || '');
+}
+
 export function shouldPreferGoogleRedirect(
   locationLike = globalThis.location,
   navigatorLike = globalThis.navigator,
   matchMediaLike = globalThis.matchMedia?.bind(globalThis)
 ) {
-  const host = locationLike?.hostname || '';
-  const userAgent = navigatorLike?.userAgent || '';
-  const standalone = Boolean(
-    matchMediaLike?.('(display-mode: standalone)')?.matches || navigatorLike?.standalone === true
-  );
-  const inAppBrowser = /Instagram|FBAN|FBAV|Line|wv/i.test(userAgent);
-  // signInWithPopup communicates via window.opener.postMessage — no cross-origin
-  // iframe required, so it works on any deployed domain including github.io.
-  // signInWithRedirect routes through firebaseapp.com and needs a cross-origin
-  // iframe to deliver the result, which modern browsers block silently.
-  // Only force redirect for environments where popups are genuinely unusable.
-  return (
-    standalone ||
-    inAppBrowser ||
-    /iPad|iPhone|iPod/i.test(userAgent)
-  );
+  // signInWithRedirect silently fails in all modern browsers because they block
+  // the cross-origin iframe Firebase needs to deliver the token back, even when
+  // the redirect itself completes successfully. Use signInWithPopup everywhere.
+  // In-app browsers (Instagram, etc.) are handled separately with an open-externally message.
+  return false;
 }
 
 export function getGoogleLoginErrorMessage(

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getGoogleLoginErrorMessage, shouldPreferGoogleRedirect } from '../src/modules/auth.js';
+import { getGoogleLoginErrorMessage, isInAppBrowser, shouldPreferGoogleRedirect } from '../src/modules/auth.js';
 import { calculateBMR, mlFeatureVecV2, shouldAutoDeload } from '../src/modules/fitness.js';
 import { getGoalAdherenceInsights, getWeeklyProgressSummary } from '../src/modules/insights.js';
 import { APP_I18N } from '../src/modules/i18n.js';
@@ -13,37 +13,27 @@ import {
 import { formatLastSyncedLabel } from '../src/modules/ui.js';
 
 describe('login helpers', () => {
-  it('prefers redirect on iPhone browsers (popup unreliable on iOS)', () => {
+  it('uses popup on iPhone (signInWithRedirect silently fails on modern iOS due to cross-origin iframe block)', () => {
     expect(
       shouldPreferGoogleRedirect(
         { hostname: 'toskawales.github.io' },
         { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)' },
         () => ({ matches: false })
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('prefers redirect in in-app browsers', () => {
-    expect(
-      shouldPreferGoogleRedirect(
-        { hostname: 'toskawales.github.io' },
-        { userAgent: 'Mozilla/5.0 Instagram/123' },
-        () => ({ matches: false })
-      )
-    ).toBe(true);
-  });
-
-  it('prefers redirect when running as standalone PWA', () => {
+  it('uses popup when running as standalone PWA', () => {
     expect(
       shouldPreferGoogleRedirect(
         { hostname: 'toskawales.github.io' },
         { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' },
         () => ({ matches: true }) // display-mode: standalone
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('uses popup on GitHub Pages desktop (popup postMessage avoids cross-origin iframe failure)', () => {
+  it('uses popup on GitHub Pages desktop', () => {
     expect(
       shouldPreferGoogleRedirect(
         { hostname: 'toskawales.github.io' },
@@ -61,6 +51,13 @@ describe('login helpers', () => {
         () => ({ matches: false })
       )
     ).toBe(false);
+  });
+
+  it('detects in-app browsers (Instagram, Facebook) so the UI can show an open-externally prompt', () => {
+    expect(isInAppBrowser({ userAgent: 'Mozilla/5.0 Instagram/123' })).toBe(true);
+    expect(isInAppBrowser({ userAgent: 'Mozilla/5.0 FBAN/123' })).toBe(true);
+    expect(isInAppBrowser({ userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/604.1' })).toBe(false);
+    expect(isInAppBrowser({ userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' })).toBe(false);
   });
 
   it('explains unauthorized domain failures clearly', () => {


### PR DESCRIPTION
signInWithRedirect silently fails on all modern browsers (iOS, standalone PWA,
desktop) because they block the cross-origin iframe Firebase needs to deliver
the auth token back. The user would complete Google sign-in but land back on
the login screen with no error shown.

Now signInWithPopup is used for every platform. In-app browsers (Instagram,
Facebook, etc.) get a clear toast asking the user to open in their real browser
instead of silently failing. Redirect is only kept as a last-resort fallback
when the popup is genuinely blocked by the browser.

https://claude.ai/code/session_01Kw3ZYzJAe2jrRaNQwJ2p5q