### PR TITLE
Add cycle-aware training layer: phase inference, symptom modifiers, ML features

### DIFF
--- a/app.css
+++ b/app.css
@@ -40,6 +40,7 @@ body{background:#080808;color:#f2f2f2;font-family:'DM Sans',-apple-system,BlinkM
 .chip{padding:10px 16px;border:1.5px solid #3a3a3a;background:#1e1e1e;color:#ccc;border-radius:20px;cursor:pointer;font-size:13px;font-weight:500;user-select:none;display:inline-block;transition:all 0.15s;}
 .chip:active{background:#2a2a2a;}
 .chip.sel{border-color:#c8ff00!important;background:rgba(200,255,0,0.1)!important;color:#c8ff00!important;font-weight:600;}
+.btn-outline.sel{border-color:#ff69b4!important;background:rgba(255,105,180,0.1)!important;color:#ff69b4!important;}
 .chip.sel2{border-color:#ff69b4!important;background:rgba(255,105,180,0.1)!important;color:#ff69b4!important;font-weight:600;}
 .chip.sel-r{border-color:#ff6b35!important;background:rgba(255,107,53,0.1)!important;color:#ff6b35!important;font-weight:600;}
 .chip-wrap{display:flex;flex-wrap:wrap;gap:8px;}

--- a/app.js
+++ b/app.js
@@ -2891,8 +2891,9 @@ function updateCycleLogs(profile,{periodStartToday,periodEndToday,isoDate}){
     }
   }
   if(periodEndToday){
-    // Close the most recent open log (no endDate yet)
-    const openIdx=logs.findLastIndex(l=>!l.endDate);
+    // Close the most recent open log (no endDate yet) — avoid findLastIndex for older browser compat
+    let openIdx=-1;
+    for(let i=logs.length-1;i>=0;i--){if(!logs[i].endDate){openIdx=i;break;}}
     if(openIdx>=0)logs[openIdx]={...logs[openIdx],endDate:isoDate};
   }
   // Keep up to last 12 logs to bound profile size

--- a/app.js
+++ b/app.js
@@ -1677,7 +1677,15 @@ function obSel(el,key,val){
     if(cycleSection)cycleSection.style.display=val==='female'?'block':'none';
     // Default cycleProfile based on sex
     if(val!=='female')obAnswers.cycleProfile=CYCLE_PROFILES.NOT_APPLICABLE;
-    else if(!obAnswers.cycleProfile||obAnswers.cycleProfile===CYCLE_PROFILES.NOT_APPLICABLE)obAnswers.cycleProfile=CYCLE_PROFILES.EUMENORRHEIC;
+    else{
+      if(!obAnswers.cycleProfile||obAnswers.cycleProfile===CYCLE_PROFILES.NOT_APPLICABLE)obAnswers.cycleProfile=CYCLE_PROFILES.EUMENORRHEIC;
+      // Visually select the default cycle-profile card if none already selected
+      const cycleCards=document.querySelectorAll('#ob3CycleSection .opt-card');
+      if(![...cycleCards].some(c=>c.classList.contains('sel'))){
+        const defaultCard=document.querySelector('#ob3CycleSection [data-value="eumenorrheic"]');
+        if(defaultCard){cycleCards.forEach(c=>c.classList.remove('sel'));defaultCard.classList.add('sel');}
+      }
+    }
   }
   if(key==='structurePreset')selectedStructurePreset=val;
   const nb=document.getElementById('ob'+obStep+'n');
@@ -2174,7 +2182,8 @@ function buildMlDataset(checkins){
     const c=sorted[i],next=sorted[i+1];
     if(c.energy===undefined||c.stress===undefined)continue;
     const priorCheckins=sorted.slice(Math.max(0,i-3),i);
-    const x=mlFeatureVecV2(c,priorCheckins);
+    const cf=c.cycleSnapshot?buildCycleFeatures(c.cycleSnapshot,c.cycleSnapshot.crampSeverity||0):null;
+    const x=mlFeatureVecV2(c,priorCheckins,cf);
     const y=(next.lifts==='slightly_up'||next.lifts==='pbs')?1:0;
     xs.push(x);ys.push(y);
   }
@@ -2939,7 +2948,9 @@ function submitCheckin(){
     const plan=buildPlan(window.userProfile,window.currentCheckin,lastSessions,pastCheckins,recentActivities);
     window.currentPlanData=plan;
     if(window.currentUser?.uid)setCachedPlan(window.currentUser.uid,plan);
-    if(window.fbSaveCheckin)await window.fbSaveCheckin({...window.currentCheckin,planSummary:plan.summary});
+    const cycleCtx=plan.analysis?.cycle;
+    const cycleSnapshot=cycleCtx?{phase:cycleCtx.phase,confidence:cycleCtx.confidence,cycleDay:cycleCtx.cycleDay,avgCycleLength:cycleCtx.avgCycleLength,crampSeverity:cycleCtx.crampSeverity}:null;
+    if(window.fbSaveCheckin)await window.fbSaveCheckin({...window.currentCheckin,planSummary:plan.summary,...(cycleSnapshot?{cycleSnapshot}:{})});
     // Update cycle logs if user tapped period start/end
     if(window.currentCheckin.periodStartToday||window.currentCheckin.periodEndToday){
       window.userProfile=updateCycleLogs(window.userProfile,window.currentCheckin);
@@ -3776,7 +3787,7 @@ function buildPlan(profile,checkin,lastSessions=[],pastCheckins=[],recentActivit
   const splitDays=adaptSplitForPain(adaptiveSplit.splitDays,equipment,painAreas);
   const mealCount=kcal<2000?3:kcal<2800?4:kcal<3600?5:6;
   const meals=buildMeals(kcal,protein,carbs,fat,mealCount,restrictions,effectiveDietGoal);
-  return{summary:{tier,kcal,protein,carbs,fat,days,goal,bodyGoal},analysis:{energy,stress,sleep,tier,lifts,diet,kcal,protein,carbs,fat,dietGoal:effectiveDietGoal,weight,tdee,trendMsg:trend.msg,trendAdj:trend.adj,cardioAdj,block,isStr,calOverride,autoDeloadReason,activityLevel,workStyle,bodyGoal,bodyFat,painAreas,consistency,selfRating,recoveryFocus:saunaGoal,activityMultiplier,cycle:{phase:cycleInference.phase,cycleDay:cycleInference.cycleDay,confidence:cycleInference.confidence,cycleAbsenceFlag:cycleInference.cycleAbsenceFlag,isIrregular:cycleInference.isIrregular,phaseNote:cycleInference.phaseNote,crampSeverity,cycleMod},recommendationHooks:{readinessModel:'ml-ready-v1',splitSelector:profile?.recommendationHooks?.engine||'rule-based-v2',calorieTargetModel:'rule-based-calorie-v2'},ml:{...mlSignal,baseTier,adjusted:baseTier!==tier}},splitDays,isCustomSplit:adaptiveSplit.isCustomSplit||false,meals,tier,focusMuscles,experience,sIdx,splitMeta:adaptiveSplit.splitMeta};
+  return{summary:{tier,kcal,protein,carbs,fat,days,goal,bodyGoal},analysis:{energy,stress,sleep,tier,lifts,diet,kcal,protein,carbs,fat,dietGoal:effectiveDietGoal,weight,tdee,trendMsg:trend.msg,trendAdj:trend.adj,cardioAdj,block,isStr,calOverride,autoDeloadReason,activityLevel,workStyle,bodyGoal,bodyFat,painAreas,consistency,selfRating,recoveryFocus:saunaGoal,activityMultiplier,cycle:{phase:cycleInference.phase,cycleDay:cycleInference.cycleDay,confidence:cycleInference.confidence,avgCycleLength:cycleInference.avgCycleLength,cycleAbsenceFlag:cycleInference.cycleAbsenceFlag,isIrregular:cycleInference.isIrregular,phaseNote:cycleInference.phaseNote,crampSeverity,cycleMod},recommendationHooks:{readinessModel:'ml-ready-v1',splitSelector:profile?.recommendationHooks?.engine||'rule-based-v2',calorieTargetModel:'rule-based-calorie-v2'},ml:{...mlSignal,baseTier,adjusted:baseTier!==tier}},splitDays,isCustomSplit:adaptiveSplit.isCustomSplit||false,meals,tier,focusMuscles,experience,sIdx,splitMeta:adaptiveSplit.splitMeta};
 }
 
 // ── MEAL BUILDER ──
@@ -4432,6 +4443,9 @@ function renderSettings() {
   const calorieMode=p.customCalories?`${p.customCalories} kcal fixed`:`${trEnum('dietGoal',p.dietGoal)} adaptive`;
   const reminderSummary=buildProfileReminderSummary(p);
   const lastSyncLabel=formatLastSyncedLabel(getLastSyncMeta());
+  const showCycleCard=p.sex==='female'&&p.cycleProfile&&p.cycleProfile!==CYCLE_PROFILES.NOT_APPLICABLE;
+  const sortedCycleLogs=[...(p.cycleLogs||[])].filter(l=>l.startDate).sort((a,b)=>new Date(b.startDate)-new Date(a.startDate));
+  const todayIso=new Date().toISOString().split('T')[0];
   document.getElementById('settingsBody').innerHTML = `
     <div class="settings-card">
       <div class="settings-card-head">
@@ -4487,6 +4501,16 @@ function renderSettings() {
       <div class="settings-copy">You still need browser notification permission for reminders to fire.</div>
     </div>
     <div class="settings-actions"><div class="settings-actions-copy"><strong>Save profile changes</strong><span>Home, plan defaults, recovery setup, and reminders will update together.</span></div><button class="btn btn-acc" onclick="saveSettingsProfile()">Save Changes</button></div>
+    ${showCycleCard?`<div class="settings-card">
+      <div class="settings-title">Period Log</div>
+      <div class="settings-copy">Log period start and end dates. Up to 12 entries are kept — used to estimate your cycle phase and adjust training intensity.</div>
+      <div style="margin:12px 0;">${sortedCycleLogs.length?sortedCycleLogs.map(l=>`<div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0;border-bottom:1px solid rgba(255,255,255,0.06);"><span style="font-size:14px;color:#f2f2f2;">Started ${l.startDate}${l.endDate?` · Ended ${l.endDate}`:' · End not logged'}</span><button class="btn btn-outline btn-sm" onclick="deleteCycleLogEntry('${l.startDate}')">Remove</button></div>`).join(''):'<div style="font-size:13px;color:#888;padding:8px 0;">No periods logged yet.</div>'}</div>
+      <div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin-top:4px;">
+        <label class="settings-field" style="flex:1;min-width:140px;margin:0;"><span class="settings-field-label">Period start</span><input type="date" id="newCycleStart" class="settings-input" max="${todayIso}"></label>
+        <label class="settings-field" style="flex:1;min-width:140px;margin:0;"><span class="settings-field-label">End date (optional)</span><input type="date" id="newCycleEnd" class="settings-input" max="${todayIso}"></label>
+        <button class="btn btn-outline btn-sm" style="align-self:flex-end;" onclick="addCycleLogEntry()">Add Entry</button>
+      </div>
+    </div>`:''}
     <div class="settings-card">
       <div class="settings-title">${t('settings.language')}</div>
       <div class="settings-copy">ADDAPT is available in English and German. Changing language reloads the app.</div>
@@ -4507,6 +4531,30 @@ function renderSettings() {
   syncSettingsFocusHint();
   syncSettingsSaunaHint();
 }
+
+window.addCycleLogEntry=function(){
+  const startDate=document.getElementById('newCycleStart')?.value;
+  if(!startDate){showToast('Date required','Please enter a period start date.');return;}
+  const endDate=document.getElementById('newCycleEnd')?.value||undefined;
+  if(endDate&&endDate<startDate){showToast('Invalid dates','End date must be on or after start date.');return;}
+  const p=window.userProfile;if(!p)return;
+  const logs=[...(p.cycleLogs||[])];
+  if(logs.some(l=>l.startDate===startDate)){showToast('Already logged','A period starting on this date is already recorded.');return;}
+  const entry={startDate,...(endDate?{endDate}:{})};
+  logs.push(entry);
+  logs.sort((a,b)=>new Date(b.startDate)-new Date(a.startDate));
+  p.cycleLogs=logs.slice(0,12);
+  if(window.fbSaveProfile)window.fbSaveProfile(p);
+  renderSettings();
+  showToast('Entry added','Period log updated.');
+};
+window.deleteCycleLogEntry=function(startDate){
+  const p=window.userProfile;if(!p)return;
+  p.cycleLogs=(p.cycleLogs||[]).filter(l=>l.startDate!==startDate);
+  if(window.fbSaveProfile)window.fbSaveProfile(p);
+  renderSettings();
+  showToast('Entry removed','Period log updated.');
+};
 
 window.toggleNotifSetting = function(key, val) {
   if (!window.userProfile) return;

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import{buildFirstRunEmptyState,getRecommendedFocusMuscles,getRecommendedTraining
 import{formatLastSyncedLabel,registerServiceWorker}from'./src/modules/ui.js';
 import{APP_I18N}from'./src/modules/i18n.js';
 import{calculateBMR,shouldAutoDeload,mlFeatureVecV2,getMuscleRecoveryMap,getMuscleVolumeModifier,getAdaptiveScheme,deriveSessionTag}from'./src/modules/fitness.js';
+import{inferCyclePhase,getCycleSymptomModifier,buildCycleFeatures,CYCLE_PHASES,CYCLE_PROFILES}from'./src/modules/cycle.js';
 const cfg={apiKey:"AIzaSyDQKmSRuK0cpIupdwVOilD8gX88ML-3K8s",authDomain:"adaptive-plan-app.firebaseapp.com",projectId:"adaptive-plan-app",storageBucket:"adaptive-plan-app.firebasestorage.app",messagingSenderId:"214755243355",appId:"1:214755243355:web:4fe3818b936a442477967e"};
 const {auth,db,prov}=createFirebaseServices(cfg);
 registerServiceWorker();
@@ -1292,6 +1293,12 @@ function daysAgo(ms){return daysBetween(ms,Date.now());}
 // ── CHECK-IN META (show days since last) ──
 async function populateCheckinMeta(){
   const p=window.userProfile;
+  // Show cycle symptoms section for female users who have a cycle profile set
+  const cycleSection=document.getElementById('ciCycleSection');
+  if(cycleSection){
+    const showCycle=p?.sex==='female'&&p?.cycleProfile&&p.cycleProfile!==CYCLE_PROFILES.NOT_APPLICABLE;
+    cycleSection.style.display=showCycle?'block':'none';
+  }
   if(p?.weight&&p?.height&&p?.age){const sAdj=(p.sex||'male')==='female'?-161:5;const tdee=Math.round((10*(p.weight||75)+6.25*(p.height||175)-5*(p.age||25)+sAdj)*1.55);const el=document.getElementById('calCalcVal');if(el)el.textContent=tdee;}
   const badge=document.getElementById('ciSinceBadge');
   if(!badge)return;
@@ -1665,6 +1672,13 @@ function obSel(el,key,val){
   obAnswers[key]=val;
   if(key==='goal')syncSplitSuggestion();
   if(key==='bodyGoal')obAnswers.dietGoal=BODY_GOAL_TO_DIET[val]||'maintain';
+  if(key==='sex'){
+    const cycleSection=document.getElementById('ob3CycleSection');
+    if(cycleSection)cycleSection.style.display=val==='female'?'block':'none';
+    // Default cycleProfile based on sex
+    if(val!=='female')obAnswers.cycleProfile=CYCLE_PROFILES.NOT_APPLICABLE;
+    else if(!obAnswers.cycleProfile||obAnswers.cycleProfile===CYCLE_PROFILES.NOT_APPLICABLE)obAnswers.cycleProfile=CYCLE_PROFILES.EUMENORRHEIC;
+  }
   if(key==='structurePreset')selectedStructurePreset=val;
   const nb=document.getElementById('ob'+obStep+'n');
   if(nb)nb.disabled=false;
@@ -1998,6 +2012,10 @@ function sanitizeOnboardingProfile(raw){
     notifCheckin:selectedNotifPrefs.checkin!==false,
     notifEmom:!!selectedNotifPrefs.emom,
     notifSauna:!!selectedNotifPrefs.sauna,
+    // Cycle profile — only relevant for female/other sex; defaults to not_applicable
+    cycleProfile:raw.cycleProfile||(raw.sex==='female'?CYCLE_PROFILES.EUMENORRHEIC:CYCLE_PROFILES.NOT_APPLICABLE),
+    contraceptionStatus:raw.contraceptionStatus||'none',
+    cycleLogs:Array.isArray(raw.cycleLogs)?raw.cycleLogs:[],
     recommendationHooks:{
       engine:'rule-based-v2',
       mlReadyAfterCheckins:8,
@@ -2116,7 +2134,7 @@ function calcWeightTrend(checkins,currentWeight,dietGoal){
 }
 
 // ── LIGHTWEIGHT ML (ON-DEVICE) ──
-const ML_MODEL_VERSION=2;
+const ML_MODEL_VERSION=3;
 const ML_MODEL_STORAGE_KEY='addapt_ml_model_cache';
 
 function mlSigmoid(z){return 1/(1+Math.exp(-z));}
@@ -2208,7 +2226,7 @@ function calcDayOfWeekInsight(checkins){
   if(highest.avg-lowest.avg<1.0)return null;
   return{bestDay:highest.day,bestAvg:highest.avg,worstDay:lowest.day,worstAvg:lowest.avg};
 }
-function getMlReadinessSignal(pastCheckins,currentCheckin){
+function getMlReadinessSignal(pastCheckins,currentCheckin,cycleFeatures=null){
   const ds=buildMlDataset(pastCheckins);
   if(ds.xs.length<8)return{enabled:false,samples:ds.xs.length,reason:'not-enough-data'};
   const fingerprint=mlDatasetFingerprint(ds.xs,ds.ys);
@@ -2217,7 +2235,8 @@ function getMlReadinessSignal(pastCheckins,currentCheckin){
   if(!model)return{enabled:false,samples:ds.xs.length,reason:'train-failed'};
   if(!cached)mlSaveCachedModel(fingerprint,model.w,ds.xs.length);
   const priorForCurrent=pastCheckins.slice(-3);
-  const p=mlSigmoid(mlDot(model.w,mlFeatureVecV2(currentCheckin,priorForCurrent)));
+  // Pass cycle features during inference — training data uses neutral defaults
+  const p=mlSigmoid(mlDot(model.w,mlFeatureVecV2(currentCheckin,priorForCurrent,cycleFeatures)));
   const confidence=Math.abs(p-0.5)*2;
   const perf=evalMlModel(model,ds.xs,ds.ys);
   const dayInsight=calcDayOfWeekInsight(pastCheckins);
@@ -2861,6 +2880,25 @@ function renderGWCard(checkins,p){const gw=p.goalWeight,cw=checkins.find(c=>c.we
 // ════════════════════════════════════
 // CHECK-IN SUBMIT
 // ════════════════════════════════════
+// ── CYCLE LOG HELPERS ──
+function updateCycleLogs(profile,{periodStartToday,periodEndToday,isoDate}){
+  if(!profile||(!periodStartToday&&!periodEndToday))return profile;
+  const logs=[...(profile.cycleLogs||[])];
+  if(periodStartToday){
+    // Only add a new start if there isn't already one for today
+    if(!logs.some(l=>l.startDate===isoDate)){
+      logs.push({startDate:isoDate,endDate:null});
+    }
+  }
+  if(periodEndToday){
+    // Close the most recent open log (no endDate yet)
+    const openIdx=logs.findLastIndex(l=>!l.endDate);
+    if(openIdx>=0)logs[openIdx]={...logs[openIdx],endDate:isoDate};
+  }
+  // Keep up to last 12 logs to bound profile size
+  return{...profile,cycleLogs:logs.slice(-12)};
+}
+window.toggleCycleButton=function(el){el.classList.toggle('sel');};
 function setGeneratingContext(mode='checkin'){
   const title=document.getElementById('genTitle');
   const sub=document.getElementById('genSub');
@@ -2887,7 +2925,11 @@ function setGeneratingContext(mode='checkin'){
 function submitCheckin(){
   const energy=parseInt(document.getElementById('eS').value),stress=parseInt(document.getElementById('sS').value),weight=document.getElementById('ciW').value?parseFloat(document.getElementById('ciW').value):null,notes=document.getElementById('ciNotes').value||'',sleep=document.querySelector('#sleepC .chip.sel')?.dataset.val||'7-8hrs',lifts=document.querySelector('#liftC .chip.sel')?.dataset.val||'same',diet=document.querySelector('#dietC .chip.sel')?.dataset.val||'under',calOverride=getCalOverride();
   const sorenessAreas=[];
-  window.currentCheckin={energy,stress,weight,notes,sleep,lifts,diet,calOverride,sorenessAreas,isoDate:new Date().toISOString().split('T')[0],date:new Date().toLocaleDateString('en-GB')};
+  const crampSeverity=parseInt(document.getElementById('ciCrampSlider')?.value||'0')||0;
+  const cycleSymptoms=[...document.querySelectorAll('#ciCycleSympChips .chip.sel')].map(c=>c.dataset.val).filter(Boolean);
+  const periodStartToday=document.getElementById('ciPeriodStart')?.classList.contains('sel')||false;
+  const periodEndToday=document.getElementById('ciPeriodEnd')?.classList.contains('sel')||false;
+  window.currentCheckin={energy,stress,weight,notes,sleep,lifts,diet,calOverride,sorenessAreas,crampSeverity,cycleSymptoms,periodStartToday,periodEndToday,isoDate:new Date().toISOString().split('T')[0],date:new Date().toLocaleDateString('en-GB')};
   trackFlowEvent('checkin_submitted',{hasWeight:Boolean(weight),energy,stress,lifts,diet});
   goTo('generating');runSteps('checkin');
   setTimeout(async()=>{
@@ -2897,6 +2939,11 @@ function submitCheckin(){
     window.currentPlanData=plan;
     if(window.currentUser?.uid)setCachedPlan(window.currentUser.uid,plan);
     if(window.fbSaveCheckin)await window.fbSaveCheckin({...window.currentCheckin,planSummary:plan.summary});
+    // Update cycle logs if user tapped period start/end
+    if(window.currentCheckin.periodStartToday||window.currentCheckin.periodEndToday){
+      window.userProfile=updateCycleLogs(window.userProfile,window.currentCheckin);
+      if(window.fbSaveProfile)window.fbSaveProfile(window.userProfile);
+    }
     trackFlowEvent('checkin_saved',{kcal:plan.summary?.kcal||plan.analysis?.kcal||null,tier:plan.analysis?.tier||null});
     renderPlan(plan);checkMilestones(getHabitCheckins(pastCheckins).length+1);goTo('result');
   },5400);
@@ -3676,13 +3723,18 @@ function adaptSplitForPain(splitDays,equipment,painAreas=[]){
 function buildPlan(profile,checkin,lastSessions=[],pastCheckins=[],recentActivities=[]){
   if(!profile)profile={goal:'general',bodyGoal:'maintain',experience:'intermediate',days:4,sessionLen:60,focusMuscles:['chest','back'],equipment:'full',dietGoal:'maintain',restrictions:['none'],weight:75,height:175,age:25,sex:'male',activityLevel:'moderate',workStyle:'mixed',bodyFat:18,painAreas:['none'],consistency:'building',selfRating:'balanced'};
   const{goal='general',bodyGoal='maintain',experience='beginner',days=3,sessionLen=60,focusMuscles=[],equipment='full',dietGoal='maintain',restrictions=['none'],weight:pw,height=175,age=25,sex='male',customCalories,activityLevel='moderate',workStyle='mixed',bodyFat=18,painAreas=['none'],consistency='building',selfRating='balanced',saunaGoal='recovery'}=profile;
-  const{energy,stress,sleep,lifts,diet,weight:cw,calOverride,sorenessAreas=[]}=checkin;
+  const{energy,stress,sleep,lifts,diet,weight:cw,calOverride,sorenessAreas=[],crampSeverity=0,cycleSymptoms=[]}=checkin;
   const weight=cw||pw||75;
   let tier;if(energy<=3)tier=0;else if(energy<=5)tier=((sleep==='7-8hrs'||sleep==='8+hrs')&&stress<=5)?1:0;else if(energy<=7)tier=(sleep==='<5hrs'||stress>=8)?1:2;else tier=((sleep==='<5hrs'||sleep==='5-6hrs')&&stress>=7)?1:2;
   const baseTier=tier;
   const autoDeloadReason=getAutoDeloadTrigger(pastCheckins,lastSessions);
   if(autoDeloadReason)tier=0;
-  const mlSignal=getMlReadinessSignal(pastCheckins,checkin);
+  // Cycle phase inference — used as a soft contextual modifier, not a dominant driver
+  const cycleProfile=profile.cycleProfile||CYCLE_PROFILES.NOT_APPLICABLE;
+  const cycleLogs=profile.cycleLogs||[];
+  const cycleInference=inferCyclePhase(cycleLogs,cycleProfile);
+  const cfVec=buildCycleFeatures(cycleInference,crampSeverity);
+  const mlSignal=getMlReadinessSignal(pastCheckins,checkin,cfVec);
   if(!autoDeloadReason&&mlSignal.enabled&&mlSignal.confidence>=0.18){
     if(mlSignal.probability>=0.67&&tier<2)tier++;
     else if(mlSignal.probability<=0.33&&tier>0)tier--;
@@ -3691,6 +3743,9 @@ function buildPlan(profile,checkin,lastSessions=[],pastCheckins=[],recentActivit
   else if(consistency==='building'&&tier===2&&pastCheckins.length<2)tier=1;
   if(selfRating==='need_support'&&tier>0)tier--;
   if(selfRating==='ready_to_push'&&energy>=7&&stress<=6&&(sleep==='7-8hrs'||sleep==='8+hrs'))tier=Math.min(2,tier+1);
+  // Cycle symptom modifier — soft constraint, only applies when not already auto-deloading
+  const cycleMod=getCycleSymptomModifier(cycleInference.phase,crampSeverity,cycleSymptoms,cycleInference.confidence);
+  if(!autoDeloadReason&&cycleMod.isApplied&&tier>0)tier=Math.max(0,tier+cycleMod.tierDelta);
   const block=calcBlock(pastCheckins);const isStr=block.isStr&&tier!==0;
   const RR={beginner:{comp:{2:'10–15',1:'12–15',0:'15'},iso:{2:'12–15',1:'15',0:'15–20'}},intermediate:{comp:{2:'8–12',1:'10–12',0:'12–15'},iso:{2:'10–12',1:'12',0:'15'}},advanced:{comp:{2:'6–10',1:'8–10',0:'10–12'},iso:{2:'8–10',1:'10',0:'12'}}};
   const SRR={beginner:{comp:{2:'6–8',1:'8–10',0:'10–12'},iso:{2:'8–10',1:'10',0:'12'}},intermediate:{comp:{2:'3–6',1:'5–6',0:'8–10'},iso:{2:'6–8',1:'8',0:'10'}},advanced:{comp:{2:'1–5',1:'3–5',0:'6–8'},iso:{2:'4–6',1:'6',0:'8'}}};
@@ -3720,7 +3775,7 @@ function buildPlan(profile,checkin,lastSessions=[],pastCheckins=[],recentActivit
   const splitDays=adaptSplitForPain(adaptiveSplit.splitDays,equipment,painAreas);
   const mealCount=kcal<2000?3:kcal<2800?4:kcal<3600?5:6;
   const meals=buildMeals(kcal,protein,carbs,fat,mealCount,restrictions,effectiveDietGoal);
-  return{summary:{tier,kcal,protein,carbs,fat,days,goal,bodyGoal},analysis:{energy,stress,sleep,tier,lifts,diet,kcal,protein,carbs,fat,dietGoal:effectiveDietGoal,weight,tdee,trendMsg:trend.msg,trendAdj:trend.adj,cardioAdj,block,isStr,calOverride,autoDeloadReason,activityLevel,workStyle,bodyGoal,bodyFat,painAreas,consistency,selfRating,recoveryFocus:saunaGoal,activityMultiplier,recommendationHooks:{readinessModel:'ml-ready-v1',splitSelector:profile?.recommendationHooks?.engine||'rule-based-v2',calorieTargetModel:'rule-based-calorie-v2'},ml:{...mlSignal,baseTier,adjusted:baseTier!==tier}},splitDays,isCustomSplit:adaptiveSplit.isCustomSplit||false,meals,tier,focusMuscles,experience,sIdx,splitMeta:adaptiveSplit.splitMeta};
+  return{summary:{tier,kcal,protein,carbs,fat,days,goal,bodyGoal},analysis:{energy,stress,sleep,tier,lifts,diet,kcal,protein,carbs,fat,dietGoal:effectiveDietGoal,weight,tdee,trendMsg:trend.msg,trendAdj:trend.adj,cardioAdj,block,isStr,calOverride,autoDeloadReason,activityLevel,workStyle,bodyGoal,bodyFat,painAreas,consistency,selfRating,recoveryFocus:saunaGoal,activityMultiplier,cycle:{phase:cycleInference.phase,cycleDay:cycleInference.cycleDay,confidence:cycleInference.confidence,cycleAbsenceFlag:cycleInference.cycleAbsenceFlag,isIrregular:cycleInference.isIrregular,phaseNote:cycleInference.phaseNote,crampSeverity,cycleMod},recommendationHooks:{readinessModel:'ml-ready-v1',splitSelector:profile?.recommendationHooks?.engine||'rule-based-v2',calorieTargetModel:'rule-based-calorie-v2'},ml:{...mlSignal,baseTier,adjusted:baseTier!==tier}},splitDays,isCustomSplit:adaptiveSplit.isCustomSplit||false,meals,tier,focusMuscles,experience,sIdx,splitMeta:adaptiveSplit.splitMeta};
 }
 
 // ── MEAL BUILDER ──
@@ -3751,7 +3806,13 @@ function renderPlan(plan,activeTab='overview',focusDay=''){
     ?`<div style="padding:12px;background:rgba(0,212,255,0.05);border:1px solid rgba(0,212,255,0.22);border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:#00d4ff;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">ML Performance · v${ml.version}${ml.cached?' · cached':''}</div><div style="font-size:13px;color:#f2f2f2;line-height:1.5;">Accuracy ${(ml.performance.accuracy*100).toFixed(0)}% · Brier loss ${ml.performance.brier.toFixed(3)} · ${ml.performance.samples} training samples</div></div>`
     :'';
   const cardioAdjHtml=cardioAdj?`<div style="padding:12px;background:rgba(200,255,0,0.05);border:1px solid rgba(200,255,0,0.15);border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:#c8ff00;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">Cardio Adjustment · +${cardioAdj} kcal/day</div><div style="font-size:13px;color:#f2f2f2;">Weekly cardio activity is raising your daily calorie target to offset the burn. Keep logging runs, swims and cycles to keep it accurate.</div></div>`:'';
-  document.getElementById('tab-overview').innerHTML=`<div class="stat-row"><div class="stat-box"><div class="stat-val">${energy}/10</div><div class="stat-lbl">Energy</div></div><div class="stat-box"><div class="stat-val">${kcal}</div><div class="stat-lbl">kcal${calOverride?' (custom)':''}</div></div><div class="stat-box"><div class="stat-val">${protein}g</div><div class="stat-lbl">Protein</div></div><div class="stat-box"><div class="stat-val">${{0:'Deload',1:'Mod',2:'Full'}[tier]}</div><div class="stat-lbl">Mode</div></div></div><div class="block-card ${isStr?'str':'hyp'}"><div class="block-tag">${isStr?'Strength Block':'Hypertrophy Block'}</div><div class="block-name">${block.name} Block — Week ${block.week} of ${block.total}</div><div class="block-desc">${isStr?'Lower reps, heavier weight, 3–4 min rest. Neural adaptation.':'Higher reps, moderate weight, shorter rest. Muscle growth and volume.'}</div>${block.earlyTrigger?`<div style="font-size:12px;color:#ffaa00;margin-bottom:8px;">${block.earlyTrigger}</div>`:''}<div class="block-row"><div class="block-bar-track"><div class="block-bar-fill" style="width:${Math.round(block.week/block.total*100)}%;"></div></div><div class="block-weeks">${block.week}/${block.total} weeks</div></div></div><h2>Analysis</h2><p>Recovery: <strong>${{0:'poor — deload week',1:'moderate — controlled effort',2:'strong — push hard'}[tier]}</strong></p>${mlInsight}${mlPerfCard}${autoDeloadReason?`<p style="color:#ffaa00;">${autoDeloadReason}</p>`:''}<p>${{regressed:'Lifts went backwards. Do not add weight — fix recovery and nutrition first.',same:'Held steady. Target +1 rep or 2.5kg on at least one compound.',slightly_up:'Good progress. Keep increments small and consistent.',pbs:'PRs hit. Ride this momentum carefully.'}[analysis.lifts]||''}</p><p>${dietMsg}</p>${trendMsg?`<div style="padding:12px;background:${trendAdj>0?'rgba(200,255,0,0.05)':trendAdj<0?'rgba(255,77,0,0.05)':'rgba(255,255,255,0.02)'};border:1px solid ${trendAdj>0?'rgba(200,255,0,0.15)':trendAdj<0?'rgba(255,77,0,0.15)':'rgba(255,255,255,0.06)'};border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:${trendAdj>0?'#c8ff00':trendAdj<0?'#ff4d00':'#888'};letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">Weight Trend${trendAdj?` · ${trendAdj>0?'+':''}${trendAdj} kcal`:''}</div><div style="font-size:13px;color:#f2f2f2;">${trendMsg}</div></div>`:''}${cardioAdjHtml}<h2>Macros</h2><ul><li><span>Daily Calories</span><span class="li-r">${kcal} kcal${calOverride?' (custom)':''}</span></li><li><span>TDEE estimate</span><span class="li-r">${tdee} kcal</span></li>${cardioAdj?`<li><span>Cardio adjustment</span><span class="li-r" style="color:#c8ff00;">+${cardioAdj} kcal/day</span></li>`:''}<li><span>Protein</span><span class="li-r">${protein}g · ${protein*4} kcal</span></li><li><span>Carbs</span><span class="li-r">${carbs}g · ${carbs*4} kcal</span></li><li><span>Fats</span><span class="li-r">${fat}g · ${fat*9} kcal</span></li></ul><h2>Profile</h2><ul><li><span>Goal</span><span class="li-r">${cap(p.goal||'general')}</span></li><li><span>Body goal</span><span class="li-r">${BODY_GOAL_LABELS[analysis.bodyGoal||p.bodyGoal||'maintain']||cap(analysis.bodyGoal||p.bodyGoal||'maintain')}</span></li><li><span>Focus muscles</span><span class="li-r">${(focusMuscles||[]).map(cap).join(' & ')}</span></li><li><span>Experience</span><span class="li-r">${cap(experience)}</span></li><li><span>Split</span><span class="li-r">${isCustomSplit?'Custom':'Auto'} · ${p.days||4} days · ${p.sessionLen||60} min</span></li><li><span>Body fat est.</span><span class="li-r">${p.bodyFat?`${p.bodyFat}%`:'—'}</span></li><li><span>Lifestyle</span><span class="li-r">${cap(String(analysis.activityLevel||p.activityLevel||'moderate').replace(/_/g,' '))} · ${cap(String(analysis.workStyle||p.workStyle||'mixed').replace(/_/g,' '))}</span></li><li><span>Pain flags</span><span class="li-r">${(analysis.painAreas||p.painAreas||[]).filter(v=>v&&v!=='none').map(v=>cap(String(v).replace(/_/g,' '))).join(' · ')||'None'}</span></li><li><span>Diet goal</span><span class="li-r">${cap(dietGoal)}</span></li></ul>${profileHtml}${freqHtml}${setHtml}${whyHtml}`;
+  const cycleCtx=analysis.cycle;
+  const PHASE_LABEL={menstrual:'Menstrual',early_follicular:'Early Follicular',ovulatory:'Ovulatory',early_luteal:'Early Luteal',late_luteal:'Late Luteal',unknown:'Unknown'};
+  const cycleCardHtml=cycleCtx&&cycleCtx.phase&&cycleCtx.phase!==CYCLE_PHASES.UNKNOWN&&cycleCtx.confidence>0
+    ?`<div style="padding:12px;background:rgba(255,105,180,0.05);border:1px solid rgba(255,105,180,0.18);border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:#ff69b4;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">Cycle Context · ${PHASE_LABEL[cycleCtx.phase]||cycleCtx.phase}${cycleCtx.cycleDay?` · Day ${cycleCtx.cycleDay}`:''}</div><div style="font-size:13px;color:#f2f2f2;line-height:1.5;">${cycleCtx.cycleMod?.isApplied?cycleCtx.cycleMod.note:'Cycle phase noted — no adjustment needed based on your logged symptoms today.'}</div>${cycleCtx.cycleAbsenceFlag?`<div style="font-size:12px;color:#ffaa00;margin-top:6px;">No period logged in over 90 days. If this is unexpected, consider speaking with a clinician.</div>`:''}<div style="font-size:11px;color:#888;margin-top:6px;">Confidence ${Math.round(cycleCtx.confidence*100)}% · Cycle is one of several signals — symptoms and readiness drive most adjustments.</div></div>`
+    :cycleCtx?.cycleAbsenceFlag?`<div style="padding:12px;background:rgba(255,170,0,0.05);border:1px solid rgba(255,170,0,0.18);border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:#ffaa00;letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">Cycle Log</div><div style="font-size:13px;color:#f2f2f2;">No period logged in over 90 days. If this is unexpected, consider speaking with a clinician.</div></div>`
+    :'';
+  document.getElementById('tab-overview').innerHTML=`<div class="stat-row"><div class="stat-box"><div class="stat-val">${energy}/10</div><div class="stat-lbl">Energy</div></div><div class="stat-box"><div class="stat-val">${kcal}</div><div class="stat-lbl">kcal${calOverride?' (custom)':''}</div></div><div class="stat-box"><div class="stat-val">${protein}g</div><div class="stat-lbl">Protein</div></div><div class="stat-box"><div class="stat-val">${{0:'Deload',1:'Mod',2:'Full'}[tier]}</div><div class="stat-lbl">Mode</div></div></div><div class="block-card ${isStr?'str':'hyp'}"><div class="block-tag">${isStr?'Strength Block':'Hypertrophy Block'}</div><div class="block-name">${block.name} Block — Week ${block.week} of ${block.total}</div><div class="block-desc">${isStr?'Lower reps, heavier weight, 3–4 min rest. Neural adaptation.':'Higher reps, moderate weight, shorter rest. Muscle growth and volume.'}</div>${block.earlyTrigger?`<div style="font-size:12px;color:#ffaa00;margin-bottom:8px;">${block.earlyTrigger}</div>`:''}<div class="block-row"><div class="block-bar-track"><div class="block-bar-fill" style="width:${Math.round(block.week/block.total*100)}%;"></div></div><div class="block-weeks">${block.week}/${block.total} weeks</div></div></div><h2>Analysis</h2><p>Recovery: <strong>${{0:'poor — deload week',1:'moderate — controlled effort',2:'strong — push hard'}[tier]}</strong></p>${mlInsight}${mlPerfCard}${cycleCardHtml}${autoDeloadReason?`<p style="color:#ffaa00;">${autoDeloadReason}</p>`:''}<p>${{regressed:'Lifts went backwards. Do not add weight — fix recovery and nutrition first.',same:'Held steady. Target +1 rep or 2.5kg on at least one compound.',slightly_up:'Good progress. Keep increments small and consistent.',pbs:'PRs hit. Ride this momentum carefully.'}[analysis.lifts]||''}</p><p>${dietMsg}</p>${trendMsg?`<div style="padding:12px;background:${trendAdj>0?'rgba(200,255,0,0.05)':trendAdj<0?'rgba(255,77,0,0.05)':'rgba(255,255,255,0.02)'};border:1px solid ${trendAdj>0?'rgba(200,255,0,0.15)':trendAdj<0?'rgba(255,77,0,0.15)':'rgba(255,255,255,0.06)'};border-radius:10px;margin-bottom:12px;"><div style="font-size:10px;color:${trendAdj>0?'#c8ff00':trendAdj<0?'#ff4d00':'#888'};letter-spacing:0.1em;text-transform:uppercase;margin-bottom:4px;">Weight Trend${trendAdj?` · ${trendAdj>0?'+':''}${trendAdj} kcal`:''}</div><div style="font-size:13px;color:#f2f2f2;">${trendMsg}</div></div>`:''}${cardioAdjHtml}<h2>Macros</h2><ul><li><span>Daily Calories</span><span class="li-r">${kcal} kcal${calOverride?' (custom)':''}</span></li><li><span>TDEE estimate</span><span class="li-r">${tdee} kcal</span></li>${cardioAdj?`<li><span>Cardio adjustment</span><span class="li-r" style="color:#c8ff00;">+${cardioAdj} kcal/day</span></li>`:''}<li><span>Protein</span><span class="li-r">${protein}g · ${protein*4} kcal</span></li><li><span>Carbs</span><span class="li-r">${carbs}g · ${carbs*4} kcal</span></li><li><span>Fats</span><span class="li-r">${fat}g · ${fat*9} kcal</span></li></ul><h2>Profile</h2><ul><li><span>Goal</span><span class="li-r">${cap(p.goal||'general')}</span></li><li><span>Body goal</span><span class="li-r">${BODY_GOAL_LABELS[analysis.bodyGoal||p.bodyGoal||'maintain']||cap(analysis.bodyGoal||p.bodyGoal||'maintain')}</span></li><li><span>Focus muscles</span><span class="li-r">${(focusMuscles||[]).map(cap).join(' & ')}</span></li><li><span>Experience</span><span class="li-r">${cap(experience)}</span></li><li><span>Split</span><span class="li-r">${isCustomSplit?'Custom':'Auto'} · ${p.days||4} days · ${p.sessionLen||60} min</span></li><li><span>Body fat est.</span><span class="li-r">${p.bodyFat?`${p.bodyFat}%`:'—'}</span></li><li><span>Lifestyle</span><span class="li-r">${cap(String(analysis.activityLevel||p.activityLevel||'moderate').replace(/_/g,' '))} · ${cap(String(analysis.workStyle||p.workStyle||'mixed').replace(/_/g,' '))}</span></li><li><span>Pain flags</span><span class="li-r">${(analysis.painAreas||p.painAreas||[]).filter(v=>v&&v!=='none').map(v=>cap(String(v).replace(/_/g,' '))).join(' · ')||'None'}</span></li><li><span>Diet goal</span><span class="li-r">${cap(dietGoal)}</span></li></ul>${profileHtml}${freqHtml}${setHtml}${whyHtml}`;
   // Training tab — custom split banner + customize button
   const customSplitBanner=isCustomSplit
     ?`<div class="custom-split-banner"><span class="custom-split-badge">Custom Split</span><span class="custom-split-note">Your structure is locked in — sets &amp; rep ranges still adapt automatically.</span><div class="custom-split-actions"><button class="btn btn-outline btn-sm" onclick="openCustomSplitModal()">Edit Split</button><button class="btn btn-outline btn-sm" onclick="resetCustomSplit()">Reset to Auto</button></div></div>`

--- a/index.html
+++ b/index.html
@@ -78,6 +78,17 @@
         <div class="opt-card" data-key="sex" data-value="female" onclick="obSel(this,'sex','female')"><div class="opt-label">Female</div></div>
         <div class="opt-card" data-key="sex" data-value="other" onclick="obSel(this,'sex','other')"><div class="opt-label">Other</div></div>
       </div>
+      <!-- Cycle profile — only shown for female users -->
+      <div id="ob3CycleSection" style="display:none;margin-top:22px;">
+        <div class="ob-sub" style="margin-bottom:10px;">Cycle profile <span style="color:#888;font-weight:400;">(optional — helps personalise around symptoms)</span></div>
+        <div class="opt-grid c2">
+          <div class="opt-card" data-key="cycleProfile" data-value="eumenorrheic" onclick="obSel(this,'cycleProfile','eumenorrheic')"><div class="opt-label">Regular cycle</div><div class="opt-desc">Fairly consistent monthly periods.</div></div>
+          <div class="opt-card" data-key="cycleProfile" data-value="hormonal_contraception" onclick="obSel(this,'cycleProfile','hormonal_contraception')"><div class="opt-label">Hormonal contraception</div><div class="opt-desc">Pill, patch, implant, or hormonal IUD.</div></div>
+          <div class="opt-card" data-key="cycleProfile" data-value="irregular" onclick="obSel(this,'cycleProfile','irregular')"><div class="opt-label">Irregular / PCOS</div><div class="opt-desc">Variable or unpredictable cycles.</div></div>
+          <div class="opt-card" data-key="cycleProfile" data-value="perimenopause" onclick="obSel(this,'cycleProfile','perimenopause')"><div class="opt-label">Perimenopause / menopause</div><div class="opt-desc">Changing or absent periods.</div></div>
+        </div>
+        <div class="premium-note" style="margin-top:10px;">Cycle phase is one signal among many — symptoms and readiness always take priority. You can skip this and it won't affect your plan.</div>
+      </div>
     </div>
     <div class="foot"><button class="btn btn-outline btn-sm" onclick="obBack(3)">Back</button><button class="btn btn-acc" onclick="obNext(3)" id="ob3n" disabled>Continue</button></div>
   </div>
@@ -508,6 +519,28 @@
     <div class="ci-section"><div class="ci-label">Diet</div><div class="ci-q">How has eating been?</div><div class="chip-wrap" id="dietC"><div class="chip" onclick="selC(this,'dietC')" data-val="way_under">Way under</div><div class="chip sel" onclick="selC(this,'dietC')" data-val="under">Slightly under</div><div class="chip" onclick="selC(this,'dietC')" data-val="on_target">On target</div><div class="chip" onclick="selC(this,'dietC')" data-val="over">Over target</div></div></div>
 
     <div class="ci-section"><div class="ci-label">Notes (optional)</div><div class="ci-q">Pain, highlights or anything to flag?</div><textarea class="textarea" id="ciNotes" placeholder="e.g. Left knee sore, hit a bench PR, skipped a few sessions"></textarea></div>
+    <!-- Cycle section — shown only when profile.sex === 'female' and cycleProfile !== not_applicable -->
+    <div class="ci-section" id="ciCycleSection" style="display:none;">
+      <div class="ci-label">Cycle <span style="font-size:10px;color:#888;font-weight:400;letter-spacing:0;">· optional</span></div>
+      <div class="ci-q" style="margin-bottom:10px;">Period log</div>
+      <div style="display:flex;gap:8px;margin-bottom:14px;">
+        <button class="btn btn-outline btn-sm" id="ciPeriodStart" onclick="toggleCycleButton(this)" style="flex:1;">Period started today</button>
+        <button class="btn btn-outline btn-sm" id="ciPeriodEnd" onclick="toggleCycleButton(this)" style="flex:1;">Period ended today</button>
+      </div>
+      <div class="ci-q">Cramp severity</div>
+      <input type="range" class="range-inp" id="ciCrampSlider" min="0" max="5" value="0" oninput="document.getElementById('ciCrampVal').textContent=this.value">
+      <div class="slider-lbl"><span>None</span><span>Severe</span></div>
+      <div class="slider-val" id="ciCrampVal">0</div>
+      <div class="ci-q" style="margin-top:14px;">Symptoms today</div>
+      <div class="chip-wrap" id="ciCycleSympChips">
+        <div class="chip" data-val="fatigue" onclick="this.classList.toggle('sel')">Fatigue</div>
+        <div class="chip" data-val="bloating" onclick="this.classList.toggle('sel')">Bloating</div>
+        <div class="chip" data-val="mood" onclick="this.classList.toggle('sel')">Mood changes</div>
+        <div class="chip" data-val="headache" onclick="this.classList.toggle('sel')">Headache</div>
+        <div class="chip" data-val="breast_tenderness" onclick="this.classList.toggle('sel')">Breast tenderness</div>
+      </div>
+      <div style="font-size:11px;color:#555;margin-top:8px;">These are one signal among several — symptoms affect load only when they're severe and combined with low energy or readiness.</div>
+    </div>
     <div class="ci-section"><div class="ci-label">Stress</div><div class="ci-q">Overall stress level?</div><input type="range" class="range-inp" id="sS" min="1" max="10" value="4" oninput="updS('sS','sV',this.value)"><div class="slider-lbl"><span>Relaxed</span><span>Maxed out</span></div><div class="slider-val" id="sV">4</div></div>
   </div>
   <div class="foot"><button class="btn btn-acc" onclick="submitCheckin()">Generate My Plan</button></div>

--- a/src/modules/cycle.js
+++ b/src/modules/cycle.js
@@ -1,0 +1,262 @@
+/**
+ * Menstrual cycle phase inference, feature extraction, and symptom modifiers.
+ * All functions are pure — no side effects, no I/O.
+ *
+ * Design principles (per evidence-based design doc):
+ *  - Cycle phase is a contextual signal, not the whole program.
+ *  - Phase info only reduces tier; it never raises it alone.
+ *  - Hormonal contraception and irregular cycles get low/zero phase confidence.
+ *  - Symptoms and readiness remain the primary drivers.
+ */
+
+export const CYCLE_PROFILES = {
+  EUMENORRHEIC: 'eumenorrheic',
+  HORMONAL_CONTRACEPTION: 'hormonal_contraception',
+  IRREGULAR: 'irregular',
+  PERIMENOPAUSE: 'perimenopause',
+  NOT_APPLICABLE: 'not_applicable',
+};
+
+export const CYCLE_PHASES = {
+  MENSTRUAL: 'menstrual',
+  EARLY_FOLLICULAR: 'early_follicular',
+  OVULATORY: 'ovulatory',
+  EARLY_LUTEAL: 'early_luteal',
+  LATE_LUTEAL: 'late_luteal',
+  UNKNOWN: 'unknown',
+};
+
+/**
+ * Compute average cycle length in days from logged period start dates.
+ * Uses up to the last 6 cycle intervals. Returns null if fewer than 2 logs.
+ *
+ * @param {object[]} cycleLogs - Array of { startDate: 'YYYY-MM-DD', endDate?: string }
+ * @returns {number|null}
+ */
+export function calcAvgCycleLength(cycleLogs = []) {
+  const starts = [...cycleLogs]
+    .filter(l => l.startDate)
+    .map(l => new Date(l.startDate).getTime())
+    .sort((a, b) => a - b);
+  if (starts.length < 2) return null;
+  const intervals = [];
+  for (let i = 1; i < Math.min(starts.length, 7); i++) {
+    const days = (starts[i] - starts[i - 1]) / 86400000;
+    if (days >= 18 && days <= 60) intervals.push(days);
+  }
+  if (!intervals.length) return null;
+  return intervals.reduce((s, v) => s + v, 0) / intervals.length;
+}
+
+/**
+ * Compute cycle length variability (std dev of inter-period intervals in days).
+ * Returns null if fewer than 3 cycles logged.
+ *
+ * @param {object[]} cycleLogs
+ * @returns {number|null}
+ */
+export function calcCycleLengthVariability(cycleLogs = []) {
+  const starts = [...cycleLogs]
+    .filter(l => l.startDate)
+    .map(l => new Date(l.startDate).getTime())
+    .sort((a, b) => a - b);
+  if (starts.length < 3) return null;
+  const intervals = [];
+  for (let i = 1; i < Math.min(starts.length, 7); i++) {
+    const days = (starts[i] - starts[i - 1]) / 86400000;
+    if (days >= 18 && days <= 60) intervals.push(days);
+  }
+  if (intervals.length < 2) return null;
+  const avg = intervals.reduce((s, v) => s + v, 0) / intervals.length;
+  const variance = intervals.reduce((s, v) => s + (v - avg) ** 2, 0) / intervals.length;
+  return Math.sqrt(variance);
+}
+
+/**
+ * Infer the current menstrual cycle phase from logged periods.
+ *
+ * Phase boundaries are approximate calendar estimates — not hormone measurements.
+ * Confidence is reduced for irregular cycles, limited log history, or when the
+ * current cycle day exceeds the user's expected cycle length.
+ *
+ * @param {object[]} cycleLogs - Array of { startDate: 'YYYY-MM-DD', endDate?: string }
+ * @param {string} cycleProfile - One of CYCLE_PROFILES values
+ * @param {string|null} todayIso - ISO date for today (defaults to now)
+ * @returns {{
+ *   phase: string,
+ *   cycleDay: number|null,
+ *   confidence: number,
+ *   daysSinceLastBleed: number|null,
+ *   avgCycleLength: number|null,
+ *   variability: number|null,
+ *   cycleAbsenceFlag: boolean,
+ *   isIrregular: boolean,
+ *   phaseNote: string|null
+ * }}
+ */
+export function inferCyclePhase(cycleLogs = [], cycleProfile = 'eumenorrheic', todayIso = null) {
+  const today = todayIso ? new Date(todayIso) : new Date();
+  const todayMs = today.getTime();
+  const fallback = {
+    phase: CYCLE_PHASES.UNKNOWN,
+    cycleDay: null,
+    confidence: 0,
+    daysSinceLastBleed: null,
+    avgCycleLength: null,
+    variability: null,
+    cycleAbsenceFlag: false,
+    isIrregular: false,
+    phaseNote: null,
+  };
+
+  if (!cycleProfile || cycleProfile === CYCLE_PROFILES.NOT_APPLICABLE) return fallback;
+
+  if (cycleProfile === CYCLE_PROFILES.HORMONAL_CONTRACEPTION) {
+    // Pill bleeds don't reflect endogenous hormone cycling — skip phase inference
+    return {
+      ...fallback,
+      phaseNote: 'Hormonal contraception active — calendar phase inference skipped.',
+    };
+  }
+
+  const sortedLogs = [...cycleLogs]
+    .filter(l => l.startDate)
+    .sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
+
+  if (!sortedLogs.length) {
+    return {
+      ...fallback,
+      cycleAbsenceFlag: true,
+    };
+  }
+
+  const lastStart = new Date(sortedLogs[0].startDate);
+  const lastEnd = sortedLogs[0].endDate ? new Date(sortedLogs[0].endDate) : null;
+  const daysSinceLastBleed = (todayMs - lastStart.getTime()) / 86400000;
+  const cycleAbsenceFlag = daysSinceLastBleed > 90;
+
+  const avgCycleLength = calcAvgCycleLength(cycleLogs) ?? 28;
+  const variability = calcCycleLengthVariability(cycleLogs);
+
+  const isIrregular =
+    cycleProfile === CYCLE_PROFILES.IRREGULAR ||
+    cycleProfile === CYCLE_PROFILES.PERIMENOPAUSE ||
+    (variability !== null && variability > 7);
+
+  const cycleDay = Math.max(1, Math.round(daysSinceLastBleed) + 1);
+
+  // Confidence degrades with distance past expected next period, irregular cycles, limited history
+  let confidence = 1.0;
+  if (cycleDay > avgCycleLength + 5) confidence = 0.3;
+  else if (cycleDay > avgCycleLength) confidence = 0.6;
+  if (isIrregular) confidence *= 0.5;
+  if (sortedLogs.length < 2) confidence *= 0.7;
+  confidence = Math.max(0, Math.min(1, confidence));
+
+  // Assume period lasts at most 7 days when no explicit endDate is logged
+  const DEFAULT_BLEED_DAYS = 7;
+  const isStillBleeding = lastEnd
+    ? todayMs <= lastEnd.getTime()
+    : daysSinceLastBleed < DEFAULT_BLEED_DAYS;
+  let phase;
+  if (isStillBleeding || cycleDay <= 5) {
+    phase = CYCLE_PHASES.MENSTRUAL;
+  } else if (cycleDay <= 12) {
+    phase = CYCLE_PHASES.EARLY_FOLLICULAR;
+  } else if (cycleDay <= 15) {
+    phase = CYCLE_PHASES.OVULATORY;
+  } else if (cycleDay <= 21) {
+    phase = CYCLE_PHASES.EARLY_LUTEAL;
+  } else {
+    phase = CYCLE_PHASES.LATE_LUTEAL;
+  }
+
+  return {
+    phase,
+    cycleDay,
+    confidence,
+    daysSinceLastBleed,
+    avgCycleLength,
+    variability,
+    cycleAbsenceFlag,
+    isIrregular,
+    phaseNote: null,
+  };
+}
+
+/**
+ * Return a soft tier modifier based on cycle phase and logged symptoms.
+ *
+ * The cycle signal only reduces tier — it never raises it alone.
+ * Requires confidence >= 0.4 to apply any change (below that, phase label
+ * is too uncertain to act on).
+ *
+ * @param {string} phase - Current phase from CYCLE_PHASES
+ * @param {number} crampSeverity - 0–5 scale (0 = none, 5 = severe)
+ * @param {string[]} cycleSymptoms - e.g. ['fatigue', 'bloating', 'mood', 'headache']
+ * @param {number} confidence - Phase confidence 0–1
+ * @returns {{ tierDelta: number, note: string|null, isApplied: boolean }}
+ */
+export function getCycleSymptomModifier(phase, crampSeverity = 0, cycleSymptoms = [], confidence = 0) {
+  if (confidence < 0.4) return { tierDelta: 0, note: null, isApplied: false };
+
+  const hasSevereCramps = crampSeverity >= 4;
+  const hasModerateCramps = crampSeverity >= 2;
+  const hasFatigue = cycleSymptoms.includes('fatigue');
+
+  if (phase === CYCLE_PHASES.MENSTRUAL && hasSevereCramps && hasFatigue) {
+    return {
+      tierDelta: -1,
+      note: 'Severe cramps and fatigue logged — intensity reduced. Cycle phase was a secondary factor; sleep and energy are the primary signals.',
+      isApplied: true,
+    };
+  }
+  if (phase === CYCLE_PHASES.MENSTRUAL && hasSevereCramps) {
+    return {
+      tierDelta: -1,
+      note: 'Severe cramps logged — lighter session offered to keep you moving without added stress.',
+      isApplied: true,
+    };
+  }
+  if (phase === CYCLE_PHASES.LATE_LUTEAL && hasModerateCramps && hasFatigue) {
+    return {
+      tierDelta: -1,
+      note: 'Pre-menstrual fatigue and cramps logged — load pulled back to support consistency over this phase.',
+      isApplied: true,
+    };
+  }
+
+  return { tierDelta: 0, note: null, isApplied: false };
+}
+
+/**
+ * Build 4 normalised cycle-related ML features for appending to the feature vector.
+ *
+ * Features:
+ *  [0] Phase position (0 = menstrual … 0.9 = late luteal, 0.5 = unknown/neutral)
+ *  [1] Phase confidence (0–1)
+ *  [2] Cycle day normalised to avg cycle length (0–1)
+ *  [3] Cramp severity normalised (0–1, from 0–5 input)
+ *
+ * @param {object} cycleInference - Output of inferCyclePhase
+ * @param {number} crampSeverity - 0–5
+ * @returns {number[]} Always returns exactly 4 values
+ */
+export function buildCycleFeatures(cycleInference = {}, crampSeverity = 0) {
+  const phaseToNum = {
+    [CYCLE_PHASES.MENSTRUAL]: 0.0,
+    [CYCLE_PHASES.EARLY_FOLLICULAR]: 0.2,
+    [CYCLE_PHASES.OVULATORY]: 0.45,
+    [CYCLE_PHASES.EARLY_LUTEAL]: 0.7,
+    [CYCLE_PHASES.LATE_LUTEAL]: 0.9,
+    [CYCLE_PHASES.UNKNOWN]: 0.5,
+  };
+  const phaseNum = phaseToNum[cycleInference.phase] ?? 0.5;
+  const conf = cycleInference.confidence ?? 0;
+  const cycleDayNorm =
+    cycleInference.cycleDay != null
+      ? Math.min(1, cycleInference.cycleDay / (cycleInference.avgCycleLength || 28))
+      : 0.5;
+  const crampNorm = Math.min(1, (crampSeverity || 0) / 5);
+  return [phaseNum, conf, cycleDayNorm, crampNorm];
+}

--- a/src/modules/cycle.js
+++ b/src/modules/cycle.js
@@ -123,17 +123,19 @@ export function inferCyclePhase(cycleLogs = [], cycleProfile = 'eumenorrheic', t
     .filter(l => l.startDate)
     .sort((a, b) => new Date(b.startDate) - new Date(a.startDate));
 
-  if (!sortedLogs.length) {
-    return {
-      ...fallback,
-      cycleAbsenceFlag: true,
-    };
-  }
+  // No logs yet — user may simply not have started tracking; don't flag absence
+  if (!sortedLogs.length) return fallback;
 
   const lastStart = new Date(sortedLogs[0].startDate);
   const lastEnd = sortedLogs[0].endDate ? new Date(sortedLogs[0].endDate) : null;
   const daysSinceLastBleed = (todayMs - lastStart.getTime()) / 86400000;
-  const cycleAbsenceFlag = daysSinceLastBleed > 90;
+
+  // Only flag absence when the user has at least one logged period that is
+  // genuinely overdue. Suppress for profiles where long gaps are expected.
+  const isProfileWithExpectedGaps =
+    cycleProfile === CYCLE_PROFILES.PERIMENOPAUSE ||
+    cycleProfile === CYCLE_PROFILES.IRREGULAR;
+  const cycleAbsenceFlag = !isProfileWithExpectedGaps && daysSinceLastBleed > 90;
 
   const avgCycleLength = calcAvgCycleLength(cycleLogs) ?? 28;
   const variability = calcCycleLengthVariability(cycleLogs);

--- a/src/modules/fitness.js
+++ b/src/modules/fitness.js
@@ -242,15 +242,32 @@ export function getAdaptiveScheme(baseSch, exName, sessions = [], sorenessAreas 
 }
 
 /**
- * Build the enhanced ML feature vector (v2) for a single check-in.
- * Includes bias term, current check-in signals, day-of-week, and
- * rolling 3-day average energy/stress from prior check-ins.
+ * Build the enhanced ML feature vector (v3) for a single check-in.
+ * Includes bias term, current check-in signals, day-of-week,
+ * rolling 3-day average energy/stress, and 4 optional cycle features.
+ *
+ * Vector layout (14 elements):
+ *  [0]  bias
+ *  [1]  energy (0–1)
+ *  [2]  inverted stress (0–1)
+ *  [3]  sleep quality (0–1)
+ *  [4]  lift result (0–1)
+ *  [5]  diet adherence (0–1)
+ *  [6]  normalised bodyweight
+ *  [7]  day-of-week (0=Mon … 1=Sun)
+ *  [8]  rolling energy (3-day avg, 0–1)
+ *  [9]  rolling inverted stress (3-day avg, 0–1)
+ *  [10] cycle phase position (0–1, 0.5=unknown/neutral)
+ *  [11] phase confidence (0–1)
+ *  [12] cycle day normalised to avg cycle length (0–1)
+ *  [13] cramp severity normalised (0–1)
  *
  * @param {object} c - Current check-in
  * @param {object[]} priorCheckins - Up to 3 most-recent prior check-ins
+ * @param {number[]|null} cycleFeatures - 4-element array from buildCycleFeatures(), or null for neutral defaults
  * @returns {number[]}
  */
-export function mlFeatureVecV2(c, priorCheckins = []) {
+export function mlFeatureVecV2(c, priorCheckins = [], cycleFeatures = null) {
   const mlSleepVal = (v) =>
     ({ '<5hrs': 0, '5-6hrs': 0.35, '7-8hrs': 0.75, '8+hrs': 1 }[v] ?? 0.5);
   const mlLiftVal = (v) =>
@@ -279,17 +296,28 @@ export function mlFeatureVecV2(c, priorCheckins = []) {
           10
       : 1 - (parseFloat(c.stress) || 5) / 10;
 
+  // Cycle features — neutral defaults when no cycle data available:
+  //   phase=0.5 (mid-cycle), confidence=0, cycleDay=0.5, cramps=0
+  const cf =
+    Array.isArray(cycleFeatures) && cycleFeatures.length === 4
+      ? cycleFeatures
+      : [0.5, 0, 0.5, 0];
+
   return [
-    1, // bias
-    Math.max(0, Math.min(1, (parseFloat(c.energy) || 5) / 10)),
-    Math.max(0, Math.min(1, 1 - (parseFloat(c.stress) || 5) / 10)),
-    mlSleepVal(c.sleep),
-    mlLiftVal(c.lifts),
-    mlDietVal(c.diet),
-    Math.max(0, Math.min(1, (parseFloat(c.weight) || 75) / 140)),
-    dowNorm,
-    rollEnergy,
-    rollStress,
+    1, // [0] bias
+    Math.max(0, Math.min(1, (parseFloat(c.energy) || 5) / 10)),  // [1]
+    Math.max(0, Math.min(1, 1 - (parseFloat(c.stress) || 5) / 10)), // [2]
+    mlSleepVal(c.sleep),   // [3]
+    mlLiftVal(c.lifts),    // [4]
+    mlDietVal(c.diet),     // [5]
+    Math.max(0, Math.min(1, (parseFloat(c.weight) || 75) / 140)), // [6]
+    dowNorm,               // [7]
+    rollEnergy,            // [8]
+    rollStress,            // [9]
+    cf[0],                 // [10] cycle phase position
+    cf[1],                 // [11] phase confidence
+    cf[2],                 // [12] cycle day norm
+    cf[3],                 // [13] cramp severity norm
   ];
 }
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  inferCyclePhase,
+  getCycleSymptomModifier,
+  buildCycleFeatures,
+  calcAvgCycleLength,
+  calcCycleLengthVariability,
+  CYCLE_PHASES,
+  CYCLE_PROFILES,
+} from '../src/modules/cycle.js';
 import { getGoogleLoginErrorMessage, isInAppBrowser, shouldPreferGoogleRedirect } from '../src/modules/auth.js';
 import { calculateBMR, mlFeatureVecV2, shouldAutoDeload } from '../src/modules/fitness.js';
 import { getGoalAdherenceInsights, getWeeklyProgressSummary } from '../src/modules/insights.js';
@@ -209,8 +218,8 @@ describe('mlFeatureVecV2', () => {
     isoDate: '2025-01-06', // Monday
   };
 
-  it('returns a 10-element vector', () => {
-    expect(mlFeatureVecV2(baseCheckin)).toHaveLength(10);
+  it('returns a 14-element vector (10 base + 4 cycle features)', () => {
+    expect(mlFeatureVecV2(baseCheckin)).toHaveLength(14);
   });
 
   it('first element is bias term 1', () => {
@@ -370,6 +379,180 @@ describe('getAdaptiveScheme', () => {
   it('returns base scheme when null inputs are provided', () => {
     expect(getAdaptiveScheme(null, 'bench', [], [], 'chest')).toBeNull();
     expect(getAdaptiveScheme('3×8–12', null, [], [], 'chest')).toBe('3×8–12');
+  });
+});
+
+// ── CYCLE MODULE ──
+
+describe('calcAvgCycleLength', () => {
+  it('returns null with fewer than 2 logs', () => {
+    expect(calcAvgCycleLength([])).toBeNull();
+    expect(calcAvgCycleLength([{ startDate: '2025-01-01' }])).toBeNull();
+  });
+
+  it('returns the interval between two periods', () => {
+    const logs = [{ startDate: '2025-01-01' }, { startDate: '2025-01-29' }];
+    const avg = calcAvgCycleLength(logs);
+    expect(avg).toBeCloseTo(28, 0);
+  });
+
+  it('averages multiple cycle intervals', () => {
+    const logs = [
+      { startDate: '2025-01-01' },
+      { startDate: '2025-01-29' }, // 28 days
+      { startDate: '2025-02-28' }, // 30 days
+    ];
+    const avg = calcAvgCycleLength(logs);
+    expect(avg).toBeCloseTo(29, 0);
+  });
+
+  it('ignores implausible intervals (< 18 days or > 60 days)', () => {
+    const logs = [
+      { startDate: '2025-01-01' },
+      { startDate: '2025-01-05' }, // 4 days — filtered out
+      { startDate: '2025-02-05' }, // 31 days — valid
+    ];
+    const avg = calcAvgCycleLength(logs);
+    // Only the 31-day interval is valid; needs 2+ logs for calculation
+    // After filtering the 4-day interval, only one interval remains — still valid
+    expect(avg).toBeCloseTo(31, 0);
+  });
+});
+
+describe('calcCycleLengthVariability', () => {
+  it('returns null with fewer than 3 logs', () => {
+    expect(calcCycleLengthVariability([])).toBeNull();
+    expect(calcCycleLengthVariability([{ startDate: '2025-01-01' }, { startDate: '2025-01-29' }])).toBeNull();
+  });
+
+  it('returns near-zero variability for perfectly regular cycles', () => {
+    const logs = [
+      { startDate: '2025-01-01' },
+      { startDate: '2025-01-29' },
+      { startDate: '2025-02-26' },
+      { startDate: '2025-03-26' },
+    ];
+    const v = calcCycleLengthVariability(logs);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThan(1);
+  });
+});
+
+describe('inferCyclePhase', () => {
+  it('returns UNKNOWN for not_applicable profile', () => {
+    const result = inferCyclePhase([], 'not_applicable', '2025-06-15');
+    expect(result.phase).toBe(CYCLE_PHASES.UNKNOWN);
+    expect(result.confidence).toBe(0);
+  });
+
+  it('returns UNKNOWN with phaseNote for hormonal contraception', () => {
+    const result = inferCyclePhase(
+      [{ startDate: '2025-06-01' }],
+      CYCLE_PROFILES.HORMONAL_CONTRACEPTION,
+      '2025-06-15'
+    );
+    expect(result.phase).toBe(CYCLE_PHASES.UNKNOWN);
+    expect(result.phaseNote).toBeTruthy();
+  });
+
+  it('infers menstrual phase on day 1–5', () => {
+    const logs = [{ startDate: '2025-06-14', endDate: null }];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-14');
+    expect(result.phase).toBe(CYCLE_PHASES.MENSTRUAL);
+    expect(result.cycleDay).toBe(1);
+  });
+
+  it('infers early follicular phase around day 8', () => {
+    const logs = [{ startDate: '2025-06-01', endDate: '2025-06-05' }];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-09');
+    expect(result.phase).toBe(CYCLE_PHASES.EARLY_FOLLICULAR);
+  });
+
+  it('infers late luteal phase in the final days before next period', () => {
+    const logs = [
+      { startDate: '2025-05-01' },
+      { startDate: '2025-06-01' }, // 31-day cycle; day 25 = late luteal
+    ];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-25');
+    expect(result.phase).toBe(CYCLE_PHASES.LATE_LUTEAL);
+  });
+
+  it('sets cycleAbsenceFlag when no period logged in > 90 days', () => {
+    const logs = [{ startDate: '2024-01-01' }];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-15');
+    expect(result.cycleAbsenceFlag).toBe(true);
+  });
+
+  it('reduces confidence for irregular cycle profile', () => {
+    const regularLogs = [
+      { startDate: '2025-05-01' },
+      { startDate: '2025-06-01' },
+    ];
+    const regularResult = inferCyclePhase(regularLogs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-10');
+    const irregularResult = inferCyclePhase(regularLogs, CYCLE_PROFILES.IRREGULAR, '2025-06-10');
+    expect(irregularResult.confidence).toBeLessThan(regularResult.confidence);
+  });
+});
+
+describe('getCycleSymptomModifier', () => {
+  it('returns no change when confidence is below threshold', () => {
+    const result = getCycleSymptomModifier(CYCLE_PHASES.MENSTRUAL, 5, ['fatigue'], 0.3);
+    expect(result.isApplied).toBe(false);
+    expect(result.tierDelta).toBe(0);
+  });
+
+  it('reduces tier on menstrual phase with severe cramps and fatigue', () => {
+    const result = getCycleSymptomModifier(CYCLE_PHASES.MENSTRUAL, 4, ['fatigue'], 0.8);
+    expect(result.isApplied).toBe(true);
+    expect(result.tierDelta).toBe(-1);
+    expect(result.note).toBeTruthy();
+  });
+
+  it('reduces tier on menstrual phase with severe cramps alone', () => {
+    const result = getCycleSymptomModifier(CYCLE_PHASES.MENSTRUAL, 4, [], 0.8);
+    expect(result.isApplied).toBe(true);
+    expect(result.tierDelta).toBe(-1);
+  });
+
+  it('reduces tier in late luteal phase with moderate cramps and fatigue', () => {
+    const result = getCycleSymptomModifier(CYCLE_PHASES.LATE_LUTEAL, 2, ['fatigue'], 0.8);
+    expect(result.isApplied).toBe(true);
+    expect(result.tierDelta).toBe(-1);
+  });
+
+  it('returns no change in follicular phase with mild symptoms', () => {
+    const result = getCycleSymptomModifier(CYCLE_PHASES.EARLY_FOLLICULAR, 1, ['bloating'], 0.8);
+    expect(result.isApplied).toBe(false);
+    expect(result.tierDelta).toBe(0);
+  });
+});
+
+describe('buildCycleFeatures', () => {
+  it('returns exactly 4 values', () => {
+    const result = buildCycleFeatures({ phase: CYCLE_PHASES.MENSTRUAL, confidence: 0.9, cycleDay: 3, avgCycleLength: 28 }, 2);
+    expect(result).toHaveLength(4);
+  });
+
+  it('all values are between 0 and 1', () => {
+    const result = buildCycleFeatures({ phase: CYCLE_PHASES.LATE_LUTEAL, confidence: 0.7, cycleDay: 25, avgCycleLength: 28 }, 5);
+    result.forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('uses neutral defaults when cycleInference is empty', () => {
+    const result = buildCycleFeatures({}, 0);
+    expect(result[0]).toBe(0.5); // unknown phase → neutral
+    expect(result[1]).toBe(0);   // zero confidence
+    expect(result[3]).toBe(0);   // no cramps
+  });
+
+  it('menstrual phase maps to 0.0, late luteal to 0.9', () => {
+    const menstrual = buildCycleFeatures({ phase: CYCLE_PHASES.MENSTRUAL, confidence: 1, cycleDay: 2, avgCycleLength: 28 }, 0);
+    const lateLuteal = buildCycleFeatures({ phase: CYCLE_PHASES.LATE_LUTEAL, confidence: 1, cycleDay: 25, avgCycleLength: 28 }, 0);
+    expect(menstrual[0]).toBe(0.0);
+    expect(lateLuteal[0]).toBe(0.9);
   });
 });
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -477,10 +477,28 @@ describe('inferCyclePhase', () => {
     expect(result.phase).toBe(CYCLE_PHASES.LATE_LUTEAL);
   });
 
-  it('sets cycleAbsenceFlag when no period logged in > 90 days', () => {
+  it('does NOT set cycleAbsenceFlag when no periods have ever been logged', () => {
+    // New users who haven't started tracking should not see the clinician prompt
+    const result = inferCyclePhase([], CYCLE_PROFILES.EUMENORRHEIC, '2025-06-15');
+    expect(result.cycleAbsenceFlag).toBe(false);
+  });
+
+  it('sets cycleAbsenceFlag when last logged period was > 90 days ago', () => {
     const logs = [{ startDate: '2024-01-01' }];
     const result = inferCyclePhase(logs, CYCLE_PROFILES.EUMENORRHEIC, '2025-06-15');
     expect(result.cycleAbsenceFlag).toBe(true);
+  });
+
+  it('does NOT set cycleAbsenceFlag for perimenopause even after a long gap', () => {
+    const logs = [{ startDate: '2024-01-01' }];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.PERIMENOPAUSE, '2025-06-15');
+    expect(result.cycleAbsenceFlag).toBe(false);
+  });
+
+  it('does NOT set cycleAbsenceFlag for irregular cycle profile after a long gap', () => {
+    const logs = [{ startDate: '2024-01-01' }];
+    const result = inferCyclePhase(logs, CYCLE_PROFILES.IRREGULAR, '2025-06-15');
+    expect(result.cycleAbsenceFlag).toBe(false);
   });
 
   it('reduces confidence for irregular cycle profile', () => {


### PR DESCRIPTION
Implements the design doc's Phase 1 (rules-first) cycle-awareness:

- New src/modules/cycle.js: pure-function module for menstrual cycle phase
  inference (eumenorrheic/hormonal-contraception/irregular/perimenopause/
  not_applicable profiles), symptom modifier that soft-reduces tier on severe
  cramps in menstrual and late-luteal phases, 4-feature ML vector slot, and
  cycle absence flag (> 90 days without logged period).

- fitness.js: extends mlFeatureVecV2 from 10 to 14 elements by appending 4
  cycle context features (phase position, confidence, cycle-day norm, cramp
  severity). Neutral defaults [0.5, 0, 0.5, 0] apply when no cycle data
  exists, so male/no-cycle users are unaffected.

- app.js: imports cycle module; bumps ML_MODEL_VERSION to 3 to invalidate
  cached 10-weight models; passes cycle features through getMlReadinessSignal
  for inference; applies getCycleSymptomModifier as a soft post-ML tier
  modifier in buildPlan (cycle signal only reduces tier, never raises it,
  never overrides autoDeload); stores cycleProfile/contraceptionStatus/
  cycleLogs in sanitized onboarding profile; adds updateCycleLogs helper
  called on checkin save when period start/end is logged; adds cycle context
  card to plan overview tab; shows cycle section in check-in for female users.

- index.html: adds conditional cycle-profile sub-section in onboarding step 3
  (only visible when sex=female); adds cycle symptoms section in check-in
  (cramp severity slider, symptom chips, period start/end buttons).

- smoke.test.js: updates mlFeatureVecV2 length assertion to 14; adds 20 new
  tests covering calcAvgCycleLength, calcCycleLengthVariability, inferCyclePhase,
  getCycleSymptomModifier, and buildCycleFeatures.

All 71 tests pass.

https://claude.ai/code/session_01L6JZ39qTzjeNJpg3b39Rtr